### PR TITLE
Add Dockerfile to enable Docker workflow and usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+## -*- dockerfile-image-name: "logdy-core" -*-
+FROM golang:1
+
+WORKDIR /go/src/logdy-core/
+COPY ./ /go/src/logdy-core/
+
+RUN \
+  --mount=type=cache,mode=0755,target=/root/.cache/go-build/ \
+  --mount=type=cache,mode=0755,target=/go/pkg/mod/cache/ \
+  go build -x -v \
+  && go install -x -v \
+  && go clean -v
+
+ENTRYPOINT [ "/go/bin/logdy-core", "--ui-ip", "0.0.0.0" ]
+CMD [ "stdin" ]


### PR DESCRIPTION
* Builds from local repo checkout, instead of fetching the binary from some URL. Build is auditable.
* Uses latest `golang:1.x`. Perhaps pinning to a more specific version would be desirable?
* Uses Docker's local builder cache to speed up repeated builds (useful for local development usage).
* Deliberately avoids multi-stage build, Alpine base image and other size reduction tricks, at least for now. Tries to be as much unopinionated as possible, Derived smaller images can still be achieved using this as base.

As already stated, this `Dockerfile` it's not only aimed at pulling & running (e.g. size-optimized), altough it will definitely work for that purpose. It can be used also for local development workflow without the need to install any Golang toolchain. Making it now as unopinionated as possible enables further usage cases/scenarios.

Test (from my fork & branch URL):
```console
$ # Build image straight from source Github repo URL (no clone needed)
$ docker build -t logdy https://github.com/pataquets/logdy-core.git#main
$ # Pipe some local file into a newly created container, spawned from the previosly built image
$ cat your-log-file.json | docker run --rm -i -p 8080:8080 logdy
```