### PR TITLE
Optimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1
+FROM golang:1-alpine AS builder
 
 # For available labels, see OCI Annotations Spec docs:
 # https://specs.opencontainers.org/image-spec/annotations/#pre-defined-annotation-keys
@@ -12,9 +12,13 @@ COPY ./ /go/src/logdy-core/
 RUN \
   --mount=type=cache,mode=0755,target=/root/.cache/go-build/ \
   --mount=type=cache,mode=0755,target=/go/pkg/mod/cache/ \
-  go build -x -v \
+  go build -x -v -o /go/bin/logdy-core \
   && go install -x -v \
   && go clean -v
 
-ENTRYPOINT [ "/go/bin/logdy-core", "--ui-ip", "0.0.0.0" ]
+FROM alpine:latest
+
+COPY --from=builder /go/bin/logdy-core /logdy
+
+ENTRYPOINT ["/logdy", "--ui-ip", "0.0.0.0" ]
 CMD [ "stdin" ]


### PR DESCRIPTION
By introducing alpine images for both the builder and the result images, I reduced the size of the images from 963 MB to 49 MG. 